### PR TITLE
Align tests with core Config types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           version: "latest"
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Install dependencies
         run: uv sync --all-extras
 
@@ -39,10 +44,7 @@ jobs:
       - name: Run quality gates (Python 3.12 only)
         if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }}
         run: |
-          uv run ruff check src tests --fix --config=pyproject.toml
-          uv run black src tests --config=pyproject.toml
-          uv run mypy src tests --config-file=pyproject.toml
-          uv run xenon --max-absolute B src
+          just quality
           uv run pip-audit --progress-spinner=off
           uv run validate-pyproject pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,7 @@ convention = "google"
 files = ["src", "tests"]
 python_version = "3.12"
 mypy_path = "stubs"
+plugins = ["pydantic.mypy"]
 warn_unused_ignores = true
 warn_redundant_casts = true
 # Basic safety

--- a/src/pytest_drill_sergeant/plugin/extensibility.py
+++ b/src/pytest_drill_sergeant/plugin/extensibility.py
@@ -82,9 +82,11 @@ def _create_invalid_subclass_error() -> TypeError:
     return TypeError(msg)
 
 
-def create_plugin_class[
-    P
-](name: str, base: type[P], attrs: Mapping[str, object] | None = None,) -> type[P]:
+def create_plugin_class[P](
+    name: str,
+    base: type[P],
+    attrs: Mapping[str, object] | None = None,
+) -> type[P]:
     """Create a plugin subclass with proper typing and runtime checks.
 
     Args:

--- a/src/pytest_drill_sergeant/plugin/extensibility.py
+++ b/src/pytest_drill_sergeant/plugin/extensibility.py
@@ -82,11 +82,9 @@ def _create_invalid_subclass_error() -> TypeError:
     return TypeError(msg)
 
 
-def create_plugin_class[P](
-    name: str,
-    base: type[P],
-    attrs: Mapping[str, object] | None = None,
-) -> type[P]:
+def create_plugin_class[
+    P
+](name: str, base: type[P], attrs: Mapping[str, object] | None = None,) -> type[P]:
     """Create a plugin subclass with proper typing and runtime checks.
 
     Args:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -34,10 +34,10 @@ class TestSeverity:
 
     def test_severity_values(self) -> None:
         """Test severity enum values."""
-        assert Severity.ERROR == "error"
-        assert Severity.WARNING == "warning"
-        assert Severity.INFO == "info"
-        assert Severity.HINT == "hint"
+        assert Severity.ERROR.value == "error"
+        assert Severity.WARNING.value == "warning"
+        assert Severity.INFO.value == "info"
+        assert Severity.HINT.value == "hint"
 
     def test_severity_string_conversion(self) -> None:
         """Test severity string conversion."""
@@ -50,13 +50,13 @@ class TestRuleType:
 
     def test_rule_type_values(self) -> None:
         """Test rule type enum values."""
-        assert RuleType.PRIVATE_ACCESS == "private_access"
-        assert RuleType.MOCK_OVERSPECIFICATION == "mock_overspecification"
-        assert RuleType.STRUCTURAL_EQUALITY == "structural_equality"
-        assert RuleType.AAA_COMMENT == "aaa_comment"
-        assert RuleType.DUPLICATE_TEST == "duplicate_test"
-        assert RuleType.PARAMETRIZATION == "parametrization"
-        assert RuleType.FIXTURE_EXTRACTION == "fixture_extraction"
+        assert RuleType.PRIVATE_ACCESS.value == "private_access"
+        assert RuleType.MOCK_OVERSPECIFICATION.value == "mock_overspecification"
+        assert RuleType.STRUCTURAL_EQUALITY.value == "structural_equality"
+        assert RuleType.AAA_COMMENT.value == "aaa_comment"
+        assert RuleType.DUPLICATE_TEST.value == "duplicate_test"
+        assert RuleType.PARAMETRIZATION.value == "parametrization"
+        assert RuleType.FIXTURE_EXTRACTION.value == "fixture_extraction"
 
 
 class TestFinding:
@@ -156,7 +156,7 @@ class TestFinding:
     def test_finding_required_fields(self) -> None:
         """Test finding required fields validation."""
         with pytest.raises(ValidationError):
-            Finding()  # Missing required fields
+            Finding()  # type: ignore[call-arg]
 
 
 class TestCluster:
@@ -369,7 +369,7 @@ class TestFeaturesData:
     def test_features_data_required_fields(self) -> None:
         """Test features data required fields validation."""
         with pytest.raises(ValidationError):
-            FeaturesData()  # Missing required fields
+            FeaturesData()  # type: ignore[call-arg]
 
 
 class TestModelIntegration:

--- a/tests/unit/test_plugin_hooks.py
+++ b/tests/unit/test_plugin_hooks.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from _pytest.nodes import Item
+
 from pytest_drill_sergeant.plugin.hooks import (
     pytest_addoption,
     pytest_collection_modifyitems,
@@ -107,7 +109,7 @@ class TestPytestHooks:
         """Test pytest_collection_modifyitems hook."""
         mock_session = MagicMock()
         mock_config = MagicMock()
-        mock_items = [MagicMock(), MagicMock()]
+        mock_items: list[Item] = [MagicMock(spec=Item), MagicMock(spec=Item)]
 
         # This hook currently has no implementation, just test it doesn't crash
         pytest_collection_modifyitems(mock_session, mock_config, mock_items)

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pytest_drill_sergeant.core.config import DrillSergeantConfig
+from pytest_drill_sergeant.core.models import Config
 from pytest_drill_sergeant.plugin.base import (
     AnalyzerPlugin,
     DrillSergeantPlugin,
@@ -143,7 +143,7 @@ class TestPluginRegistry:
 
     def test_register_plugin(self) -> None:
         """Test registering a plugin."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -169,7 +169,7 @@ class TestPluginRegistry:
 
     def test_register_plugin_duplicate(self) -> None:
         """Test registering a duplicate plugin."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -190,7 +190,7 @@ class TestPluginRegistry:
 
     def test_unregister_plugin(self) -> None:
         """Test unregistering a plugin."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -222,7 +222,7 @@ class TestPluginRegistry:
 
     def test_get_plugin(self) -> None:
         """Test getting a plugin by ID."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -243,7 +243,7 @@ class TestPluginRegistry:
 
     def test_get_plugins_by_category(self) -> None:
         """Test getting plugins by category."""
-        config = DrillSergeantConfig()
+        config = Config()
 
         # Register analyzer plugin
         analyzer_metadata = PluginMetadata(
@@ -285,7 +285,7 @@ class TestPluginRegistry:
 
     def test_get_enabled_plugins(self) -> None:
         """Test getting enabled plugins."""
-        config = DrillSergeantConfig()
+        config = Config()
 
         # Register enabled plugin
         enabled_metadata = PluginMetadata(
@@ -319,7 +319,7 @@ class TestPluginRegistry:
 
     def test_initialize_all(self) -> None:
         """Test initializing all plugins."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -343,7 +343,7 @@ class TestPluginRegistry:
 
     def test_initialize_all_with_exception(self) -> None:
         """Test initializing all plugins with exception."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -366,7 +366,7 @@ class TestPluginRegistry:
 
     def test_cleanup_all(self) -> None:
         """Test cleaning up all plugins."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -386,7 +386,7 @@ class TestPluginRegistry:
 
     def test_cleanup_all_with_exception(self) -> None:
         """Test cleaning up all plugins with exception."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -409,7 +409,7 @@ class TestPluginRegistry:
 
     def test_list_plugins(self) -> None:
         """Test listing all plugins."""
-        config = DrillSergeantConfig()
+        config = Config()
         metadata = PluginMetadata(
             plugin_id="test_plugin",
             name="Test Plugin",
@@ -432,7 +432,7 @@ class TestPluginManager:
 
     def setup_method(self) -> None:
         """Set up test fixtures."""
-        self.config = DrillSergeantConfig()
+        self.config = Config()
         self.manager = PluginManager(self.config)
 
     def test_init(self) -> None:


### PR DESCRIPTION
## Summary
- enable pydantic mypy plugin for accurate defaults
- update tests to use `Config` and satisfy type hints
- install `just` in CI and invoke `just quality` gates

## Testing
- `just test quality`


------
https://chatgpt.com/codex/tasks/task_e_68c5e0ef32a883268cf492b8ffc76b21