### PR TITLE
Raise minimum Python to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 maintainers = [
     { name = "Jeff Richley", email = "jeffrichley@gmail.com" }
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "pytest>=8.4.0",
     "coverage>=7.1.0",
@@ -47,6 +47,9 @@ drill-sergeant = "pytest_drill_sergeant.cli.main:cli"
 drill_sergeant = "pytest_drill_sergeant.plugin.hooks"
 
 [project.optional-dependencies]
+compat = [
+    "typing_extensions>=4.9.0 ; python_version<'3.12'",
+]
 dev = [
     "pytest>=8.4.0",
     "pytest-cov>=4.0.0",
@@ -115,7 +118,7 @@ show_missing = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py312"
+target-version = "py311"
 src = ["src"]
 exclude = [
     "stubs",
@@ -223,10 +226,11 @@ convention = "google"
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.12"
+python_version = "3.11"
 mypy_path = "stubs"
 warn_unused_ignores = true
 warn_redundant_casts = true
+strict = true
 # Basic safety
 disallow_untyped_defs = true
 disallow_incomplete_defs = true

--- a/src/pytest_drill_sergeant/core/cli_config.py
+++ b/src/pytest_drill_sergeant/core/cli_config.py
@@ -14,7 +14,7 @@ MIN_THRESHOLD_VALUE = 0
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from _pytest.config import Parser
+    from _pytest.config import Parser  # type: ignore[attr-defined]
 
 
 class ConfigError(ValueError):

--- a/src/pytest_drill_sergeant/core/reporting/output_manager.py
+++ b/src/pytest_drill_sergeant/core/reporting/output_manager.py
@@ -6,12 +6,13 @@ template-based messaging, Rich terminal output, JSON reports, and SARIF output.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
-    from pytest_drill_sergeant.core.config import Config
+    from pytest_drill_sergeant.core.config import (
+        DrillSergeantConfig as Config,
+    )
     from pytest_drill_sergeant.core.models import Finding, ResultData, RunMetrics
     from pytest_drill_sergeant.core.reporting.types import JSONDict
 from pytest_drill_sergeant.core.reporting.json_formatter import JSONReportBuilder
@@ -82,7 +83,7 @@ class OutputManager:
         Args:
             finding: Finding to print
         """
-        if self.config.output_format == "terminal":
+        if "terminal" in self.config.output_formats:
             self.rich_formatter.print_finding(finding)
 
     def print_test_result(self, result: ResultData) -> None:
@@ -91,7 +92,7 @@ class OutputManager:
         Args:
             result: Test result to print
         """
-        if self.config.output_format == "terminal":
+        if "terminal" in self.config.output_formats:
             self.rich_formatter.print_test_result(result)
 
     def print_summary(self) -> None:
@@ -104,7 +105,7 @@ class OutputManager:
             msg = "Metrics must be set before printing summary"
             raise ValueError(msg)
 
-        if self.config.output_format == "terminal":
+        if "terminal" in self.config.output_formats:
             self.rich_formatter.print_summary(self._metrics)
 
     def generate_json_report(self) -> str:
@@ -151,7 +152,9 @@ class OutputManager:
             raise ValueError(msg)
 
         if output_path is None:
-            output_path = self.config.json_report_path
+            path_str = self.config.json_report_path
+            if path_str is not None:
+                output_path = Path(path_str)
 
         if output_path is None:
             msg = "No output path specified for JSON report"
@@ -173,7 +176,9 @@ class OutputManager:
             raise ValueError(msg)
 
         if output_path is None:
-            output_path = self.config.sarif_report_path
+            path_str = self.config.sarif_report_path
+            if path_str is not None:
+                output_path = Path(path_str)
 
         if output_path is None:
             msg = "No output path specified for SARIF report"
@@ -197,15 +202,15 @@ class OutputManager:
         outputs = {}
 
         # Generate terminal output (already printed)
-        if self.config.output_format == "terminal":
+        if "terminal" in self.config.output_formats:
             outputs["terminal"] = "Printed to console"
 
         # Generate JSON output
-        if self.config.json_report_path or "json" in self.config.output_format:
+        if self.config.json_report_path or "json" in self.config.output_formats:
             outputs["json"] = self.generate_json_report()
 
         # Generate SARIF output
-        if self.config.sarif_report_path or "sarif" in self.config.output_format:
+        if self.config.sarif_report_path or "sarif" in self.config.output_formats:
             outputs["sarif"] = self.generate_sarif_report()
 
         return outputs

--- a/src/pytest_drill_sergeant/core/reporting/types.py
+++ b/src/pytest_drill_sergeant/core/reporting/types.py
@@ -8,6 +8,8 @@ type definitions.
 from __future__ import annotations
 
 # Recursive JSON types
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
-type JSONDict = dict[str, JSONValue]
+from typing import TypeAlias
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+JSONDict: TypeAlias = dict[str, JSONValue]

--- a/src/pytest_drill_sergeant/plugin/discovery.py
+++ b/src/pytest_drill_sergeant/plugin/discovery.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 try:
     from importlib.metadata import entry_points
 except ImportError:  # pragma: no cover
-    from importlib_metadata import entry_points  # type: ignore[assignment]
+    from importlib_metadata import entry_points  # type: ignore[no-redef]
 from pydantic import BaseModel
 
 # Import modules at top level to avoid runtime imports
@@ -359,7 +359,7 @@ class PluginDiscovery:
         )
 
     def _create_plugin_instance(
-        self, plugin_class: type, module_path: str, attr_name: str
+        self, plugin_class: type[DrillSergeantPlugin], module_path: str, attr_name: str
     ) -> DrillSergeantPlugin:
         """Create and register plugin instance."""
         metadata = PluginMetadata(

--- a/src/pytest_drill_sergeant/plugin/extensibility.py
+++ b/src/pytest_drill_sergeant/plugin/extensibility.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Protocol,
+    TypeAlias,
     TypeVar,
     cast,
     runtime_checkable,
@@ -29,8 +30,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 # JSON types for plugin configuration
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
 
 
 @runtime_checkable
@@ -82,9 +83,9 @@ def _create_invalid_subclass_error() -> TypeError:
     return TypeError(msg)
 
 
-def create_plugin_class[
-    P
-](name: str, base: type[P], attrs: Mapping[str, object] | None = None,) -> type[P]:
+def create_plugin_class(
+    name: str, base: type[P], attrs: Mapping[str, object] | None = None,
+) -> type[P]:
     """Create a plugin subclass with proper typing and runtime checks.
 
     Args:

--- a/src/pytest_drill_sergeant/plugin/factory.py
+++ b/src/pytest_drill_sergeant/plugin/factory.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     NotRequired,
     Protocol,
+    TypeAlias,
     TypedDict,
     TypeGuard,
     cast,
@@ -30,8 +31,8 @@ else:
     from pytest_drill_sergeant.plugin.base import PluginManager, PluginMetadata
 
 # JSON types for plugin configuration
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
 
 
 class PluginConfigRaw(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- drop Python 3.10 support and require Python 3.11+
- add typing_extensions compat extra and update lint/type configs for 3.11
- replace Python 3.12-only type syntax with TypeAlias and TypeVar patterns
- run CI on Python 3.11, 3.12 and 3.13

## Testing
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68c6e6fc99308326a8eadf77f4dba9b0