### PR TITLE
tests: fix enum/string assertions and pydantic negative tests

### DIFF
--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -34,10 +34,10 @@ class TestSeverity:
 
     def test_severity_values(self) -> None:
         """Test severity enum values."""
-        assert Severity.ERROR == "error"
-        assert Severity.WARNING == "warning"
-        assert Severity.INFO == "info"
-        assert Severity.HINT == "hint"
+        assert Severity.ERROR.value == "error"
+        assert Severity.WARNING.value == "warning"
+        assert Severity.INFO.value == "info"
+        assert Severity.HINT.value == "hint"
 
     def test_severity_string_conversion(self) -> None:
         """Test severity string conversion."""
@@ -50,13 +50,13 @@ class TestRuleType:
 
     def test_rule_type_values(self) -> None:
         """Test rule type enum values."""
-        assert RuleType.PRIVATE_ACCESS == "private_access"
-        assert RuleType.MOCK_OVERSPECIFICATION == "mock_overspecification"
-        assert RuleType.STRUCTURAL_EQUALITY == "structural_equality"
-        assert RuleType.AAA_COMMENT == "aaa_comment"
-        assert RuleType.DUPLICATE_TEST == "duplicate_test"
-        assert RuleType.PARAMETRIZATION == "parametrization"
-        assert RuleType.FIXTURE_EXTRACTION == "fixture_extraction"
+        assert RuleType.PRIVATE_ACCESS.value == "private_access"
+        assert RuleType.MOCK_OVERSPECIFICATION.value == "mock_overspecification"
+        assert RuleType.STRUCTURAL_EQUALITY.value == "structural_equality"
+        assert RuleType.AAA_COMMENT.value == "aaa_comment"
+        assert RuleType.DUPLICATE_TEST.value == "duplicate_test"
+        assert RuleType.PARAMETRIZATION.value == "parametrization"
+        assert RuleType.FIXTURE_EXTRACTION.value == "fixture_extraction"
 
 
 class TestFinding:
@@ -156,7 +156,7 @@ class TestFinding:
     def test_finding_required_fields(self) -> None:
         """Test finding required fields validation."""
         with pytest.raises(ValidationError):
-            Finding()  # Missing required fields
+            Finding.model_validate({})  # Missing required fields
 
 
 class TestCluster:
@@ -369,7 +369,7 @@ class TestFeaturesData:
     def test_features_data_required_fields(self) -> None:
         """Test features data required fields validation."""
         with pytest.raises(ValidationError):
-            FeaturesData()  # Missing required fields
+            FeaturesData.model_validate({})  # Missing required fields
 
 
 class TestModelIntegration:

--- a/tests/unit/test_models_coverage.py
+++ b/tests/unit/test_models_coverage.py
@@ -23,20 +23,20 @@ def test_models_import():
 
 def test_severity_enum():
     """Test Severity enum values."""
-    assert Severity.ERROR == "error"
-    assert Severity.WARNING == "warning"
-    assert Severity.INFO == "info"
+    assert Severity.ERROR.value == "error"
+    assert Severity.WARNING.value == "warning"
+    assert Severity.INFO.value == "info"
 
 
 def test_rule_type_enum():
     """Test RuleType enum values."""
-    assert RuleType.PRIVATE_ACCESS == "private_access"
-    assert RuleType.MOCK_OVERSPECIFICATION == "mock_overspecification"
-    assert RuleType.STRUCTURAL_EQUALITY == "structural_equality"
-    assert RuleType.AAA_COMMENT == "aaa_comment"
-    assert RuleType.DUPLICATE_TEST == "duplicate_test"
-    assert RuleType.PARAMETRIZATION == "parametrization"
-    assert RuleType.FIXTURE_EXTRACTION == "fixture_extraction"
+    assert RuleType.PRIVATE_ACCESS.value == "private_access"
+    assert RuleType.MOCK_OVERSPECIFICATION.value == "mock_overspecification"
+    assert RuleType.STRUCTURAL_EQUALITY.value == "structural_equality"
+    assert RuleType.AAA_COMMENT.value == "aaa_comment"
+    assert RuleType.DUPLICATE_TEST.value == "duplicate_test"
+    assert RuleType.PARAMETRIZATION.value == "parametrization"
+    assert RuleType.FIXTURE_EXTRACTION.value == "fixture_extraction"
 
 
 def test_finding_model():


### PR DESCRIPTION
## Summary
- compare enum members to their string values via `.value`
- validate Pydantic models with `model_validate({})` for missing-field tests

## Testing
- `uv run ruff check src tests --config=pyproject.toml`
- `uv run black --check src tests --config=pyproject.toml`
- `uv run mypy src tests --config-file=pyproject.toml` *(fails: attr-defined in test_main.py, no-untyped-call in plugin tests)*
- `uv run mypy src tests/unit/test_models.py tests/unit/test_models_coverage.py --config-file=pyproject.toml`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa68102c8326893cc7d11684ab24