### PR TITLE
refactor hooks to isolate mutation from internal planner

### DIFF
--- a/src/pytest_drill_sergeant/plugin/internals.py
+++ b/src/pytest_drill_sergeant/plugin/internals.py
@@ -1,0 +1,25 @@
+"""Internal helpers for pytest hook implementations.
+
+This module exposes pure functions that operate on abstract sequences of
+``_pytest.nodes.Item`` objects. The public pytest hook consumes and mutates
+``list[Item]`` at the boundary while internals rely on ``Sequence[Item]``
+for read-only access.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type checking only
+    from collections.abc import Sequence
+
+    from _pytest.nodes import Item
+
+
+def plan_item_order(items: Sequence[Item]) -> list[Item]:
+    """Return a new list of items in the desired execution order.
+
+    The function is pure: it never mutates ``items`` and always returns a
+    new list. The current policy performs a stable sort by ``nodeid``.
+    """
+    return sorted(items, key=lambda i: i.nodeid)


### PR DESCRIPTION
## Summary
- add pure `plan_item_order` internal API using abstract sequences
- limit mutation to `pytest_collection_modifyitems` boundary
- exercise new planner and hook mutation in tests

## Testing
- `uv run ruff check src tests --fix`
- `uv run mypy src/pytest_drill_sergeant/plugin/hooks.py src/pytest_drill_sergeant/plugin/internals.py tests/unit/test_plugin_hooks.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6fcc0d150832688249b73b4693fd5