### PR TITLE
fix: restore public param names

### DIFF
--- a/src/pytest_drill_sergeant/core/logging_utils.py
+++ b/src/pytest_drill_sergeant/core/logging_utils.py
@@ -109,17 +109,19 @@ def get_logger(name: str) -> logging.Logger:
     return logging.getLogger(name)
 
 
-def create_progress_logger(_logger: logging.Logger) -> object | None:
+def create_progress_logger(logger: logging.Logger) -> object | None:
     """Create a progress logger if rich is available.
 
     Args:
-        _logger: Base logger instance (unused but kept for API consistency)
+        logger: Base logger instance (unused but kept for API consistency)
 
     Returns:
         Rich Progress instance if available, None otherwise
     """
     if not RICH_AVAILABLE:
         return None
+
+    _ = logger  # Preserve API without triggering unused-argument warnings
 
     return Progress(
         SpinnerColumn(),

--- a/src/pytest_drill_sergeant/plugin/hooks.py
+++ b/src/pytest_drill_sergeant/plugin/hooks.py
@@ -35,7 +35,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def pytest_collection_modifyitems(
-    _session: pytest.Session, _config: pytest.Config, items: list[Item]
+    session: pytest.Session, config: pytest.Config, items: list[Item]
 ) -> None:
     """Reorder collected test items in place.
 
@@ -43,6 +43,7 @@ def pytest_collection_modifyitems(
     abstract ``Sequence[Item]`` and return a new ``list[Item]``. Mutation is
     isolated to this boundary via slice assignment.
     """
+    _ = session, config  # Preserve API and clarify parameters are unused
     new_order = plan_item_order(items)
     items[:] = new_order
 


### PR DESCRIPTION
## Summary
- ensure create_progress_logger accepts `logger` keyword
- expose `session` and `config` params in pytest_collection_modifyitems hook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70042e09c8326a15d25ee3c8084fb