### PR TITLE
feat: normalize module paths across platforms

### DIFF
--- a/src/pytest_drill_sergeant/plugin/discovery.py
+++ b/src/pytest_drill_sergeant/plugin/discovery.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from pytest_drill_sergeant.core.config import DrillSergeantConfig as Config
 from pytest_drill_sergeant.plugin.base import DrillSergeantPlugin, PluginMetadata
 from pytest_drill_sergeant.plugin.factory import PluginFactory, PluginSpec
+from pytest_drill_sergeant.util.paths import normalize_module_path
 
 logger = logging.getLogger(__name__)
 
@@ -332,11 +333,7 @@ class PluginDiscovery:
 
     def _get_module_path(self, py_file: Path, search_path: Path) -> str:
         """Convert file path to module path."""
-        return (
-            str(py_file.relative_to(search_path.parent))
-            .replace("/", ".")
-            .replace(".py", "")
-        )
+        return normalize_module_path(py_file, search_path.parent)
 
     def _extract_plugin_from_module(
         self, module: object, module_path: str

--- a/src/pytest_drill_sergeant/util/__init__.py
+++ b/src/pytest_drill_sergeant/util/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for pytest-drill-sergeant."""
+
+__all__ = ["paths"]

--- a/src/pytest_drill_sergeant/util/paths.py
+++ b/src/pytest_drill_sergeant/util/paths.py
@@ -1,0 +1,25 @@
+"""Path utility helpers."""
+
+from pathlib import Path
+
+
+def normalize_module_path(py_file: Path, root: Path) -> str:
+    """Convert a Python file path under ``root`` into a dotted module path.
+
+    Examples:
+        subdir/plugin.py     -> "subdir.plugin"
+        subdir/__init__.py   -> "subdir"
+
+    Args:
+        py_file: The Python file path to convert.
+        root: Root directory that ``py_file`` is relative to.
+
+    Returns:
+        Dotted module path for the Python file.
+    """
+    rel = py_file.relative_to(root).with_suffix("")
+
+    if rel.name == "__init__":
+        rel = rel.parent
+
+    return ".".join(rel.parts)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,26 @@
+"""Tests for path utility helpers."""
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+import pytest
+
+from pytest_drill_sergeant.util.paths import normalize_module_path
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "expected"),
+    [
+        (PurePosixPath("subdir/plugin.py"), "subdir.plugin"),
+        (PureWindowsPath(r"subdir\plugin.py"), "subdir.plugin"),
+        (PurePosixPath("subdir/__init__.py"), "subdir"),
+        (PureWindowsPath(r"subdir\__init__.py"), "subdir"),
+    ],
+)
+def test_normalize_module_path_cross_platform(
+    tmp_path: Path, rel_path: Path, expected: str
+) -> None:
+    """Ensure normalize_module_path handles POSIX and Windows paths."""
+    root = tmp_path
+    py_file = root / rel_path
+    result = normalize_module_path(py_file, root)
+    assert result == expected


### PR DESCRIPTION
## Summary
- centralize module path normalization in `normalize_module_path`
- use normalized module path in plugin discovery
- test module path normalization on POSIX and Windows paths

## Testing
- `pre-commit run --files src/pytest_drill_sergeant/util/__init__.py src/pytest_drill_sergeant/util/paths.py src/pytest_drill_sergeant/plugin/discovery.py tests/unit/test_paths.py` (fails: No module named 'pydantic')
- `uv run --group dev mypy src tests` (fails: 28 errors)
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c702afa2c0832695661e896564af25