### PR TITLE
docs: add solo-maintainer release checklist guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ What it does:
 
 - validates useful test markers
 - auto-detects marker intent from path (for example `tests/unit/` -> `@pytest.mark.unit`)
+- can **write** auto-detected markers into source files (`drill_sergeant_write_markers = true`, default)
 - supports custom directory-to-marker mappings
 - reads marker declarations from both `pytest.ini` and `pyproject.toml` (`[tool.pytest.ini_options]`)
 
@@ -91,6 +92,7 @@ addopts = -p drill_sergeant
 markers =
     unit: Unit tests
     integration: Integration tests
+    e2e: End-to-end tests
 
 drill_sergeant_enabled = true
 drill_sergeant_enforce_markers = true
@@ -122,6 +124,19 @@ def test_addition() -> None:
     assert total == 5
 ```
 
+### Running by marker
+
+With markers (and optional `drill_sergeant_auto_detect_markers = true`), use pytest’s `-m` to select tests:
+
+- **Only unit tests:**  
+  `pytest -m unit`
+- **Everything except e2e:**  
+  `pytest -m "not e2e"`
+- **Unit or integration:**  
+  `pytest -m "unit or integration"`
+
+Register every marker you use in `[pytest]` `markers` (as in the minimal config above) so pytest accepts `-m` and doesn’t warn about unknown markers.
+
 ## Configuration
 
 Precedence (highest to lowest):
@@ -147,6 +162,7 @@ file_length_exclude = ["tests/legacy/*"]
 file_length_inline_ignore = true
 file_length_inline_ignore_token = "drill-sergeant: file-length ignore"
 auto_detect_markers = true
+write_markers = true
 min_description_length = 3
 max_file_length = 350
 aaa_synonyms_enabled = false
@@ -171,6 +187,7 @@ smoke = "integration"
 - `DRILL_SERGEANT_FILE_LENGTH_INLINE_IGNORE`
 - `DRILL_SERGEANT_FILE_LENGTH_INLINE_IGNORE_TOKEN`
 - `DRILL_SERGEANT_AUTO_DETECT_MARKERS`
+- `DRILL_SERGEANT_WRITE_MARKERS` (write auto-detected markers into source files)
 - `DRILL_SERGEANT_MIN_DESCRIPTION_LENGTH`
 - `DRILL_SERGEANT_MAX_FILE_LENGTH`
 - `DRILL_SERGEANT_MARKER_MAPPINGS`

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -6,6 +6,13 @@ Release flow is split:
 - Merging that PR creates a GitHub Release and version tag.
 - Trigger `release.yml` manually with `release_tag` to publish to PyPI.
 
+## Solo Maintainer Mode (Current)
+
+- Branch protection keeps required CI checks enabled and strict/up-to-date.
+- Required approving reviews are set to `0` for single-maintainer operation.
+- PR flow is still recommended for traceability, even without a review gate.
+- Re-enable `required_approving_review_count = 1` when additional maintainers join.
+
 ## Pre-Release
 
 - [ ] `main` is green in CI (`test`, `lint`, `typecheck`).

--- a/src/pytest_drill_sergeant/config.py
+++ b/src/pytest_drill_sergeant/config.py
@@ -30,6 +30,7 @@ class DrillSergeantConfig:
     marker_severity: str = "error"  # "error", "warn", or "off"
     aaa_severity: str = "error"  # "error", "warn", or "off"
     auto_detect_markers: bool = True
+    write_markers: bool = True
     min_description_length: int = 3
     max_file_length: int = 350
     file_length_mode: str = "error"  # "error", "warn", or "off"
@@ -98,6 +99,13 @@ class DrillSergeantConfig:
             config,
             "drill_sergeant_auto_detect_markers",
             env_var="DRILL_SERGEANT_AUTO_DETECT_MARKERS",
+            default=True,
+        )
+
+        write_markers = get_bool_option(
+            config,
+            "drill_sergeant_write_markers",
+            env_var="DRILL_SERGEANT_WRITE_MARKERS",
             default=True,
         )
 
@@ -207,6 +215,7 @@ class DrillSergeantConfig:
             marker_severity=marker_severity,
             aaa_severity=aaa_severity,
             auto_detect_markers=auto_detect_markers,
+            write_markers=write_markers,
             min_description_length=min_description_length,
             max_file_length=max_file_length,
             file_length_mode=file_length_mode,

--- a/src/pytest_drill_sergeant/pytest_options.py
+++ b/src/pytest_drill_sergeant/pytest_options.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=True,
         help="Auto-detect test markers from directory structure",
     )
+    parser.addini(
+        "drill_sergeant_write_markers",
+        type="bool",
+        default=True,
+        help="Write auto-detected markers into source files (when auto_detect_markers is true)",
+    )
 
     # File length options
     parser.addini(

--- a/src/pytest_drill_sergeant/utils/__init__.py
+++ b/src/pytest_drill_sergeant/utils/__init__.py
@@ -10,6 +10,7 @@ from pytest_drill_sergeant.utils.helpers import (
     get_marker_mappings,
     get_string_option,
     get_synonym_list,
+    write_markers_to_files,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "get_marker_mappings",
     "get_string_option",
     "get_synonym_list",
+    "write_markers_to_files",
 ]

--- a/tests/unit/test_pytest_options.py
+++ b/tests/unit/test_pytest_options.py
@@ -62,6 +62,7 @@ class TestPytestOptions:
             "drill_sergeant_marker_severity",
             "drill_sergeant_aaa_severity",
             "drill_sergeant_auto_detect_markers",
+            "drill_sergeant_write_markers",
             "drill_sergeant_min_description_length",
             "drill_sergeant_max_file_length",
             "drill_sergeant_file_length_mode",

--- a/tests/unit/test_write_markers_to_files.py
+++ b/tests/unit/test_write_markers_to_files.py
@@ -1,0 +1,243 @@
+"""Unit tests for write_markers_to_files helper."""
+
+from pathlib import Path
+
+import pytest
+
+from pytest_drill_sergeant.utils import write_markers_to_files
+
+
+@pytest.mark.unit
+class TestWriteMarkersToFiles:
+    """Verify write_markers_to_files inserts or replaces correctly."""
+
+    @pytest.fixture
+    def test_file_with_blank_line_before_def(self, tmp_path: Path) -> Path:
+        """File with blank line then def (decorator should replace the blank)."""
+        path = tmp_path / "test_bar.py"
+        # Line 1: blank, Line 2: blank, Line 3: def (so def at 1-based line 3)
+        path.write_text(
+            "\n"
+            "\n"
+            "def test_bar() -> None:\n"
+            "    assert True\n",
+            encoding="utf-8",
+        )
+        return path
+
+    @pytest.fixture
+    def test_file_no_blank_before_def(self, tmp_path: Path) -> Path:
+        """File with no blank before def (decorator should be inserted)."""
+        path = tmp_path / "test_baz.py"
+        path.write_text(
+            "def test_baz() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_replaces_blank_line_with_decorator_no_extra_blank(
+        self, test_file_with_blank_line_before_def: Path
+    ) -> None:
+        """# Arrange - File has blank line before def
+        # Act - write_markers_to_files with unit marker at def line
+        # Assert - Blank is replaced by decorator; no blank between decorator and def
+        """
+        # Arrange - Use fixture file with blank line then def at 1-based line 3
+        path = test_file_with_blank_line_before_def
+
+        # Act - Write unit marker at def line
+        write_markers_to_files([(path, 3, "unit")])
+
+        # Assert - Decorator replaced blank; no lines between decorator and def
+        content = path.read_text()
+        lines = content.splitlines()
+        assert "@pytest.mark.unit" in content
+        assert "def test_bar()" in content
+        def_idx = next(i for i, line in enumerate(lines) if "def test_bar()" in line)
+        assert def_idx >= 1
+        assert lines[def_idx - 1].strip() == "@pytest.mark.unit"
+        # Explicit: no lines between the decorator and the def (decorator must be immediately above)
+        decorator_idx = next(
+            i for i in range(def_idx) if "@pytest.mark.unit" in lines[i]
+        )
+        assert def_idx == decorator_idx + 1, "no lines between annotation and def"
+
+    def test_inserts_decorator_when_no_blank_before_def(
+        self, test_file_no_blank_before_def: Path
+    ) -> None:
+        """# Arrange - File has no blank before def
+        # Act - write_markers_to_files with unit marker at def line
+        # Assert - Decorator inserted; def on next line
+        """
+        # Arrange - Use fixture file with def at 1-based line 1
+        path = test_file_no_blank_before_def
+
+        # Act - Write unit marker at def line
+        write_markers_to_files([(path, 1, "unit")])
+
+        # Assert - import pytest added; decorator immediately above def; no lines between
+        content = path.read_text()
+        assert "import pytest" in content
+        lines = content.splitlines()
+        decorator_idx = next(
+            i for i, line in enumerate(lines) if "@pytest.mark.unit" in line
+        )
+        def_idx = next(i for i, line in enumerate(lines) if "def test_baz()" in line)
+        assert def_idx == decorator_idx + 1, "no lines between annotation and def"
+
+    def test_skips_when_marker_already_present(self, tmp_path: Path) -> None:
+        """# Arrange - File already has @pytest.mark.unit above def
+        # Act - write_markers_to_files for same marker
+        # Assert - No duplicate decorator; import pytest added if missing
+        """
+        # Arrange - File with decorator and def at 1-based line 2 (no import pytest)
+        path = tmp_path / "test_qux.py"
+        path.write_text(
+            "@pytest.mark.unit\n"
+            "def test_qux() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        # Act - Try to write same marker again
+        write_markers_to_files([(path, 2, "unit")])
+
+        # Assert - No duplicate decorator; import pytest added so annotation is valid
+        content = path.read_text()
+        assert content.count("@pytest.mark.unit") == 1
+        assert "import pytest" in content
+        assert "def test_qux()" in content
+
+    def test_import_pytest_after_one_line_module_docstring(self, tmp_path: Path) -> None:
+        """# Arrange - File with one-line module docstring then imports
+        # Act - write_markers_to_files adds a marker
+        # Assert - import pytest is after the docstring, not inside it
+        """
+        # Arrange - Module docstring on first line, then blank, then def
+        path = tmp_path / "test_docstring.py"
+        path.write_text(
+            '"""Unit tests for CLI."""\n'
+            "\n"
+            "def test_cli() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        # Act - Write unit marker at def (1-based line 3)
+        write_markers_to_files([(path, 3, "unit")])
+
+        # Assert - import pytest after docstring; decorator above def
+        content = path.read_text()
+        assert "import pytest" in content
+        assert "@pytest.mark.unit" in content
+        # import pytest must not appear inside the docstring (first line only has docstring)
+        first_line = content.splitlines()[0]
+        assert "import pytest" not in first_line
+        # import pytest should be after the blank following the docstring
+        lines = content.splitlines()
+        import_idx = next(i for i, line in enumerate(lines) if line.strip() == "import pytest")
+        assert import_idx >= 1
+
+    def test_import_pytest_never_inside_function_docstring(self, tmp_path: Path) -> None:
+        """# Arrange - File with function that has a docstring (triple-quotes later in file)
+        # Act - write_markers_to_files adds a marker
+        # Assert - import pytest is at module level (no indent), not inside the function
+        """
+        # Arrange - No module docstring; a function with docstring; then a test def
+        path = tmp_path / "test_func_docstring.py"
+        path.write_text(
+            "def _helper() -> None:\n"
+            '    """Create fixture.\n'
+            "    Args:\n"
+            '        root: Path.\n'
+            '    """\n'
+            "    pass\n"
+            "\n"
+            "def test_thing() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        # Act - Write unit marker at test_thing (1-based line 8)
+        write_markers_to_files([(path, 8, "unit")])
+
+        # Assert - import pytest is at module level (no leading space), never indented
+        content = path.read_text()
+        assert "import pytest" in content
+        for line in content.splitlines():
+            if "import pytest" in line:
+                assert not line.startswith(" ") and not line.startswith("\t"), (
+                    "import pytest must be at module level, not inside a docstring/function"
+                )
+                break
+
+    def test_adds_import_pytest_when_missing(self, tmp_path: Path) -> None:
+        """# Arrange - File with no pytest import
+        # Act - write_markers_to_files adds a marker
+        # Assert - File contains 'import pytest' so the annotation is valid
+        """
+        # Arrange - File with def but no import pytest (e.g. only other imports)
+        path = tmp_path / "test_no_pytest.py"
+        path.write_text(
+            "from pathlib import Path\n"
+            "\n"
+            "def test_thing() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        # Act - Write unit marker at def line (1-based line 3)
+        write_markers_to_files([(path, 3, "unit")])
+
+        # Assert - import pytest was added and decorator is present
+        content = path.read_text()
+        assert "import pytest" in content
+        assert "@pytest.mark.unit" in content
+        assert "def test_thing()" in content
+        lines = content.splitlines()
+        def_idx = next(i for i, line in enumerate(lines) if "def test_thing()" in line)
+        decorator_idx = next(
+            i for i in range(def_idx) if "@pytest.mark.unit" in lines[i]
+        )
+        assert def_idx == decorator_idx + 1, "no lines between annotation and def"
+
+    def test_multiple_tests_same_file_reverse_order(self, tmp_path: Path) -> None:
+        """# Arrange - Two defs in one file
+        # Act - write_markers_to_files for both (reverse line order)
+        # Assert - Both get decorator without shifting line numbers
+        """
+        # Arrange - File with two defs at 1-based lines 2 and 5
+        path = tmp_path / "test_multi.py"
+        path.write_text(
+            "\n"
+            "def test_first() -> None:\n"
+            "    pass\n"
+            "\n"
+            "def test_second() -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        # Act - Write markers for both (higher line first so reverse order)
+        write_markers_to_files([(path, 5, "unit"), (path, 2, "unit")])
+
+        # Assert - Both defs have decorator immediately above; no lines between
+        content = path.read_text()
+        assert content.count("@pytest.mark.unit") == 2
+        lines = content.splitlines()
+        first_def_idx = next(
+            i for i, line in enumerate(lines) if "def test_first()" in line
+        )
+        second_def_idx = next(
+            i for i, line in enumerate(lines) if "def test_second()" in line
+        )
+        # Decorator immediately above each def is the last marker line before that def
+        first_decorator_idx = max(
+            i for i in range(first_def_idx) if "@pytest.mark.unit" in lines[i]
+        )
+        second_decorator_idx = max(
+            i for i in range(second_def_idx) if "@pytest.mark.unit" in lines[i]
+        )
+        assert first_def_idx == first_decorator_idx + 1, "no lines between annotation and first def"
+        assert second_def_idx == second_decorator_idx + 1, "no lines between annotation and second def"


### PR DESCRIPTION
## Summary
- add a Solo Maintainer Mode section to the release checklist
- document current branch protection stance (required_approving_review_count = 0)
- keep CI/check strictness expectations explicit for solo operation

## Why
- codifies current operating model
- reduces ambiguity during release execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, build, or security impact.
> 
> **Overview**
> Updates `docs/Release-Checklist.md` to add a **Solo Maintainer Mode** section documenting how to run releases with branch protection/CI checks still enforced while setting required PR approvals to `0`, and noting when to restore review requirements as more maintainers join.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 207f665294a638e7f9e4b3c89f853bcdd2414e85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->